### PR TITLE
Updated passToHCs to only transfer units once.

### DIFF
--- a/Ph.VR/f/headlessclient/passToHCs.sqf
+++ b/Ph.VR/f/headlessclient/passToHCs.sqf
@@ -118,6 +118,13 @@ while {true} do {
       };
 
     } forEach (units _x);
+    
+    // Check if group has already been transfered
+    if ( _swap ) then {
+      if (_x getVariable ["hc_transfered", false]) then {
+        _swap = false;
+      };
+    };
 
     // If load balance enabled, round robin between the HCs - else pass all to HC
     if ( _swap ) then {
@@ -140,7 +147,10 @@ while {true} do {
       };
 
       // If the transfer was successful, count it for accounting and diagnostic information
-      if ( _rc ) then { _numTransfered = _numTransfered + 1; };
+      if ( _rc ) then { 
+        _x setVariable ["hc_transfered", true];
+        _numTransfered = _numTransfered + 1; 
+      };
     };
   } forEach (allGroups);
 


### PR DESCRIPTION
Items of concern is what if the HC the group was on looses connection and we've already tagged the group as transferred?

Changes that would need to be done for the above is to set the 'hc_transferred' to the number of the HC the group was put on then if we detected that a HC disconnected then find all groups the HC previously held and set them as un-transferred.