### PR TITLE
Added support for defaulting ACRE2 radios to a preset channel. (#134)

### DIFF
--- a/Ph.VR/f/radios/acre2/acre2_clientInit.sqf
+++ b/Ph.VR/f/radios/acre2/acre2_clientInit.sqf
@@ -117,5 +117,75 @@ if(_typeOfUnit != "NIL") then {
 
       };
 
+      // ====================================================================================
+
+	  // PRESET ASSIGNMENT
+
+	  waitUntil {uiSleep 0.3; count ([] call acre_api_fnc_getCurrentRadioList) > 0};
+	  uiSleep 1;
+
+	  _presetArray = switch (side _unit) do {
+	  	case blufor: {f_radios_settings_acre2_presets_blufor};
+	  	case opfor: {f_radios_settings_acre2_presets_opfor};
+	  	case independent: {f_radios_settings_acre2_presets_indfor};
+	  	default {f_radios_settings_acre2_presets_indfor};
+	  };
+
+	  _presetLRArray = switch (side _unit) do {
+	  	case blufor: {f_radios_settings_acre2_lr_presets_blufor};
+	  	case opfor: {f_radios_settings_acre2_lr_presets_opfor};
+	  	case independent: {f_radios_settings_acre2_lr_presets_indfor};
+	  	default {f_radios_settings_acre2_lr_presets_indfor};
+	  };
+
+	  _groupID = groupID (group _unit);
+	  _groupChannelIndex = -1;
+	  _groupLRChannelIndex = -1;
+
+	  _groupIDSplit = [_groupID, " "] call bis_fnc_splitString;
+	  if ((count _groupIDSplit) > 2) then {
+	  	_groupName = toUpper (_groupIDSplit select 1);
+	  	{
+	  		if (_groupName in _x) exitWith { _groupChannelIndex = _forEachIndex; };
+	  	} forEach _presetArray;
+	  	{
+	  		if (_groupName in _x) exitWith { _groupLRChannelIndex = _forEachIndex; };
+	  	} forEach _presetLRArray;
+	  };
+
+	  _radio343 = ["ACRE_PRC343"] call acre_api_fnc_getRadioByType;
+	  _radio148 = ["ACRE_PRC148"] call acre_api_fnc_getRadioByType;
+	  _radio152 = ["ACRE_PRC152"] call acre_api_fnc_getRadioByType;
+	  _radio117 = ["ACRE_PRC117F"] call acre_api_fnc_getRadioByType;
+
+	  if (_groupChannelIndex == -1) then {
+	  	systemChat format["Unknown group for channel presets (%1)", _groupID];
+	  	_groupChannelIndex = 0;
+	  };
+
+	  if (_groupLRChannelIndex == -1 && {((!isNil "_radio117") && {_radio117 != ""})}) then {
+  		systemChat format["Unknown group for LR channel presets (%1)", _groupID];
+	  	_groupLRChannelIndex = 0;
+	  };
+
+
+	  if ((!isNil "_radio343") && {_radio343 != ""}) then {
+	      [_radio343, (_groupChannelIndex + 1)] call acre_api_fnc_setRadioChannel;
+	  };
+
+
+	  if ((!isNil "_radio148") && {_radio148 != ""}) then {
+	      [_radio148, (_groupChannelIndex + 1)] call acre_api_fnc_setRadioChannel;
+	  };
+
+
+	  if ((!isNil "_radio152") && {_radio152 != ""}) then {
+	      [_radio152, (_groupChannelIndex + 1)] call acre_api_fnc_setRadioChannel;
+	  };
+
+	  if ((!isNil "_radio117") && {_radio117 != ""}) then {
+	      [_radio117, (_groupLRChannelIndex + 1)] call acre_api_fnc_setRadioChannel;
+	  };
+
   };
 };

--- a/Ph.VR/f/radios/acre2/acre2_settings.sqf
+++ b/Ph.VR/f/radios/acre2/acre2_settings.sqf
@@ -18,11 +18,11 @@ f_radios_settings_acre2_disableFrequencySplit = FALSE;
 f_radios_settings_acre2_shortRange = ["ftl","ar","aar","rat","dm","gren","r","car","smg"];
 
 // Set the list of units that get a long range
-f_radios_settings_acre2_longRange = ["co", "dc","ftl","m", "mmgag","hmgag","matag","hatag", "mtrag","msamag","sp","vc", "pp", "eng", "engm", "uav", "fo", "div"];
+f_radios_settings_acre2_longRange = ["co", "dc","ftl","m", "mmgag","hmgag","matag","hatag", "mtrag","msamag","sp","vc", "pp","fwp", "eng", "engm", "uav", "fo", "div"];
 
 // Unit types you want to give an extra long-range radio
 // E.G: ["co", "m"] would give the CO and all medics an extra long-range radios
-f_radios_settings_acre2_extraRadios = ["co","dc","fo","vc", "pp"];
+f_radios_settings_acre2_extraRadios = ["co","dc","fo","vc", "pp","fwp"];
 
 // Standard Short
 f_radios_settings_acre2_standardSHRadio = "ACRE_PRC343";
@@ -47,11 +47,115 @@ f_radios_settings_acre2_language_indfor = ["arabic"];
 // Channels names
 // first item in the array will correspond to the first channel
 // note these only work if f_radios_settings_acre2_disableFrequencySplit is set to false
-f_radios_settings_acre2_groups_blufor = ["Alpha Squad Net","Bravo Squad Net","Charlie Squad Net","Command Net","Delta Squad Net","Echo Squad Net","Foxtrot Squad Net","Blank Net","Blank Net","Air 1","Air 2","Air 3","Air 4","Air 5","Air 6","Air 7","Air 8","Air 9","Air 10","Armor 1","Armor 2","Armor 3","Armor 4","Armor 5","Armor 6","Armor 7","Armor 8","Armor 9","Attachment 1","Attachment 2","Attachment 3","Attachment 4","Attachment 5","Attachment 6","Attachment 7","Attachment 8","Attachment 9","Attachment 10"];
+f_radios_settings_acre2_groups_blufor = ["Alpha Net","Bravo Net","Charlie Net","Command Net","Delta Net","Echo Net","Foxtrot Net","Blank Net","Blank Net","Air 1","Air 2","Air 3","Air 4","Air 5","Air 6","Air 7","Air 8","Air 9","Air 10","Armor 1","Armor 2","Armor 3","Armor 4","Armor 5","Armor 6","Armor 7","Armor 8","Armor 9","Attachment 1","Attachment 2","Attachment 3","Attachment 4","Attachment 5","Attachment 6","Attachment 7","Attachment 8","Attachment 9","Attachment 10"];
 
-f_radios_settings_acre2_groups_opfor = ["Alpha Squad Net","Bravo Squad Net","Charlie Squad Net","Command Net","Delta Squad Net","Echo Squad Net","Foxtrot Squad Net","Blank Net","Blank Net","Air 1","Air 2","Air 3","Air 4","Air 5","Air 6","Air 7","Air 8","Air 9","Air 10","Armor 1","Armor 2","Armor 3","Armor 4","Armor 5","Armor 6","Armor 7","Armor 8","Armor 9","Attachment 1","Attachment 2","Attachment 3","Attachment 4","Attachment 5","Attachment 6","Attachment 7","Attachment 8","Attachment 9","Attachment 10"];
+f_radios_settings_acre2_groups_opfor = ["Alpha Net","Bravo Net","Charlie Net","Command Net","Delta Net","Echo Net","Foxtrot Net","Blank Net","Blank Net","Air 1","Air 2","Air 3","Air 4","Air 5","Air 6","Air 7","Air 8","Air 9","Air 10","Armor 1","Armor 2","Armor 3","Armor 4","Armor 5","Armor 6","Armor 7","Armor 8","Armor 9","Attachment 1","Attachment 2","Attachment 3","Attachment 4","Attachment 5","Attachment 6","Attachment 7","Attachment 8","Attachment 9","Attachment 10"];
 
-f_radios_settings_acre2_groups_indfor = ["Alpha Squad Net","Bravo Squad Net","Charlie Squad Net","Command Net","Delta Squad Net","Echo Squad Net","Foxtrot Squad Net","Blank Net","Blank Net","Air 1","Air 2","Air 3","Air 4","Air 5","Air 6","Air 7","Air 8","Air 9","Air 10","Armor 1","Armor 2","Armor 3","Armor 4","Armor 5","Armor 6","Armor 7","Armor 8","Armor 9","Attachment 1","Attachment 2","Attachment 3","Attachment 4","Attachment 5","Attachment 6","Attachment 7","Attachment 8","Attachment 9","Attachment 10"];
+f_radios_settings_acre2_groups_indfor = ["Alpha Net","Bravo Net","Charlie Net","Command Net","Delta Net","Echo Net","Foxtrot Squad Net","Blank Net","Blank Net","Air 1","Air 2","Air 3","Air 4","Air 5","Air 6","Air 7","Air 8","Air 9","Air 10","Armor 1","Armor 2","Armor 3","Armor 4","Armor 5","Armor 6","Armor 7","Armor 8","Armor 9","Attachment 1","Attachment 2","Attachment 3","Attachment 4","Attachment 5","Attachment 6","Attachment 7","Attachment 8","Attachment 9","Attachment 10"];
+
+// Default starting channel for groups
+// first item in the array will correspond to the first channel
+f_radios_settings_acre2_presets_blufor = [
+	["ASL", "A1", "A2", "A3"], // Alpha
+	["BSL", "B1", "B2", "B3"], // Bravo
+	["CSL", "C1", "C2", "C3"], // Charlie
+	["CO", "DC", "PLTHQ"], // Command
+	["DSL", "D1", "D2", "D3"], // Delta
+	["ESL", "E1", "E2", "E3"], // Echo
+	["FSL", "F1", "F2", "F3"], // Foxtrot
+	[], // Blank Net
+	[], // Blank Net
+	["TH1"], // Air 1
+	["TH2"], // Air 2
+	["TH3"], // Air 3
+	["TH4"], // Air 4
+	["TH5"], // Air 5
+	["TH6"], // Air 6
+	["TH8"], // Air 7
+	["AH1"], // Air 8
+	["FW1"], // Air 9
+	[], // Air 10
+	["IFV1", "IFV2", "IFV3", "IFV4", "IFV5", "IFV6", "IFV7", "IFV8"], // Armor 1
+	["APC1", "APC2", "APC3", "APC4"], // Armor 2
+	["TNK1"], // Armor 3
+	[], // Armor 4
+	[], // Armor 5
+	[], // Armor 6
+	[], // Armor 7
+	[], // Armor 8
+	[], // Armor 9
+	["MMG1"], // Attachment 1
+	["HMG1"], // Attachment 2
+	["MAT1"], // Attachment 3
+	["HAT1"], // Attachment 4
+	["MTR1"], // Attachment 5
+	["MSAM1"], // Attachment 6
+	["HSAM1"], // Attachment 7
+	["ST1"], // Attachment 8
+	["DT1"], // Attachment 9
+	["ENG1"] // Attachment 10
+];
+
+f_radios_settings_acre2_presets_opfor = f_radios_settings_acre2_presets_blufor;
+f_radios_settings_acre2_presets_indfor = f_radios_settings_acre2_presets_blufor;
+
+f_radios_settings_acre2_lr_presets_blufor = [
+	[], // Alpha
+	[], // Bravo
+	[], // Charlie
+	[
+	  "CO", "DC", "PLTHQ",
+	  "ASL", "BSL", "CSL", "DSL", "ESL", "FSL",
+	  "TH1", "TH2", "TH3", "TH4", "TH5", "TH6", "TH7", "TH8",
+	  "AH1", "FW1",
+	  "IFV1", "IFV2", "IFV3", "IFV4", "IFV5", "IFV6", "IFV7", "IFV8",
+	  "APC1", "APC2", "APC3", "APC4",
+	  "TNK1",
+	  "MMG1", "HMG1",
+	  "MAT1", "HAT1",
+	  "MTR1",
+	  "MSAM1", "HSAM1",
+	  "ST1", "DT1",
+	  "ENG1"
+	], // Command
+	[], // Delta
+	[], // Echo
+	[], // Foxtrot
+	[], // Blank Net
+	[], // Blank Net
+	[], // Air 1
+	[], // Air 2
+	[], // Air 3
+	[], // Air 4
+	[], // Air 5
+	[], // Air 6
+	[], // Air 7
+	[], // Air 8
+	[], // Air 9
+	[], // Air 10
+	[], // Armor 1
+	[], // Armor 2
+	[], // Armor 3
+	[], // Armor 4
+	[], // Armor 5
+	[], // Armor 6
+	[], // Armor 7
+	[], // Armor 8
+	[], // Armor 9
+	[], // Attachment 1
+	[], // Attachment 2
+	[], // Attachment 3
+	[], // Attachment 4
+	[], // Attachment 5
+	[], // Attachment 6
+	[], // Attachment 7
+	[], // Attachment 8
+	[], // Attachment 9
+	[] // Attachment 10
+];
+
+f_radios_settings_acre2_lr_presets_opfor = f_radios_settings_acre2_lr_presets_blufor;
+f_radios_settings_acre2_lr_presets_indfor = f_radios_settings_acre2_lr_presets_blufor;
 
 // ====================================================================================
 // MISC ACRE2 settings, these are all set the ACRE2 defaults

--- a/Ph.VR/f/setGroupID/f_setGroupIDs.sqf
+++ b/Ph.VR/f/setGroupID/f_setGroupIDs.sqf
@@ -13,6 +13,7 @@ _groups = [
 
 ["GrpNATO_CO","NATO CO -"],
 ["GrpNATO_DC","NATO DC -"],
+["GrpNATO_PLTHQ","NATO PLTHQ -"],
 
 ["GrpNATO_ASL","NATO ASL -"],
 ["GrpNATO_A1","NATO A1 -"],
@@ -49,6 +50,10 @@ _groups = [
 ["GrpNATO_IFV7","NATO IFV7 -"],
 ["GrpNATO_IFV8","NATO IFV8 -"],
 ["GrpNATO_TNK1","NATO TNK1 -"],
+["GrpNATO_APC1","NATO APC1 -"],
+["GrpNATO_APC2","NATO APC2 -"],
+["GrpNATO_APC3","NATO APC3 -"],
+["GrpNATO_APC4","NATO APC4 -"],
 
 ["GrpNATO_TH1","NATO TH1 -"],
 ["GrpNATO_TH2","NATO TH2 -"],
@@ -59,6 +64,7 @@ _groups = [
 ["GrpNATO_TH7","NATO TH7 -"],
 ["GrpNATO_TH8","NATO TH8 -"],
 ["GrpNATO_AH1","NATO AH1 -"],
+["GrpNATO_FW1","NATO FW1 -"],
 
 // ====================================================================================
 
@@ -67,6 +73,7 @@ _groups = [
 
 ["GrpFIA_CO","FIA CO -"],
 ["GrpFIA_DC","FIA DC -"],
+["GrpFIA_PLTHQ","FIA PLTHQ -"],
 
 ["GrpFIA_ASL","FIA ASL -"],
 ["GrpFIA_A1","FIA A1 -"],
@@ -103,6 +110,10 @@ _groups = [
 ["GrpFIA_IFV7","FIA IFV7 -"],
 ["GrpFIA_IFV8","FIA IFV8 -"],
 ["GrpFIA_TNK1","FIA TNK1 -"],
+["GrpFIA_APC1","FIA APC1 -"],
+["GrpFIA_APC2","FIA APC2 -"],
+["GrpFIA_APC3","FIA APC3 -"],
+["GrpFIA_APC4","FIA APC4 -"],
 
 ["GrpFIA_TH1","FIA TH1 -"],
 ["GrpFIA_TH2","FIA TH2 -"],
@@ -113,6 +124,7 @@ _groups = [
 ["GrpFIA_TH7","FIA TH7 -"],
 ["GrpFIA_TH8","FIA TH8 -"],
 ["GrpFIA_AH1","FIA AH1 -"],
+["GrpFIA_FW1","FIA FW1 -"],
 
 // ====================================================================================
 
@@ -121,6 +133,7 @@ _groups = [
 
 ["GrpCSAT_CO","CSAT CO -"],
 ["GrpCSAT_DC","CSAT DC -"],
+["GrpCSAT_PLTHQ","CSAT PLTHQ -"],
 
 ["GrpCSAT_ASL","CSAT ASL -"],
 ["GrpCSAT_A1","CSAT A1 -"],
@@ -157,6 +170,10 @@ _groups = [
 ["GrpCSAT_IFV7","CSAT IFV7 -"],
 ["GrpCSAT_IFV8","CSAT IFV8 -"],
 ["GrpCSAT_TNK1","CSAT TNK1 -"],
+["GrpCSAT_APC1","CSAT APC1 -"],
+["GrpCSAT_APC2","CSAT APC2 -"],
+["GrpCSAT_APC3","CSAT APC3 -"],
+["GrpCSAT_APC4","CSAT APC4 -"],
 
 ["GrpCSAT_TH1","CSAT TH1 -"],
 ["GrpCSAT_TH2","CSAT TH2 -"],
@@ -167,6 +184,7 @@ _groups = [
 ["GrpCSAT_TH7","CSAT TH7 -"],
 ["GrpCSAT_TH8","CSAT TH8 -"],
 ["GrpCSAT_AH1","CSAT AH1 -"],
+["GrpCSAT_FW1","CSAT FW1 -"],
 
 // ====================================================================================
 
@@ -175,6 +193,7 @@ _groups = [
 
 ["GrpOFIA_CO","FIA O CO -"],
 ["GrpOFIA_DC","FIA O DC -"],
+["GrpOFIA_PLTHQ","FIA O PLTHQ -"],
 
 ["GrpOFIA_ASL","FIA O ASL -"],
 ["GrpOFIA_A1","FIA O A1 -"],
@@ -211,6 +230,10 @@ _groups = [
 ["GrpOFIA_IFV7","FIA O IFV7 -"],
 ["GrpOFIA_IFV8","FIA O IFV8 -"],
 ["GrpOFIA_TNK1","FIA O TNK1 -"],
+["GrpOFIA_APC1","FIA O APC1 -"],
+["GrpOFIA_APC2","FIA O APC2 -"],
+["GrpOFIA_APC3","FIA O APC3 -"],
+["GrpOFIA_APC4","FIA O APC4 -"],
 
 ["GrpOFIA_TH1","FIA O TH1 -"],
 ["GrpOFIA_TH2","FIA O TH2 -"],
@@ -221,6 +244,7 @@ _groups = [
 ["GrpOFIA_TH7","FIA O TH7 -"],
 ["GrpOFIA_TH8","FIA O TH8 -"],
 ["GrpOFIA_AH1","FIA O AH1 -"],
+["GrpOFIA_FW1","FIA O FW1 -"],
 
 // ====================================================================================
 
@@ -229,6 +253,7 @@ _groups = [
 
 ["GrpAAF_CO","AAF CO -"],
 ["GrpAAF_DC","AAF DC -"],
+["GrpAAF_PLTHQ","AAF PLTHQ -"],
 
 ["GrpAAF_ASL","AAF ASL -"],
 ["GrpAAF_A1","AAF A1 -"],
@@ -265,6 +290,10 @@ _groups = [
 ["GrpAAF_IFV7","AAF IFV7 -"],
 ["GrpAAF_IFV8","AAF IFV8 -"],
 ["GrpAAF_TNK1","AAF TNK1 -"],
+["GrpAAF_APC1","AAF APC1 -"],
+["GrpAAF_APC2","AAF APC2 -"],
+["GrpAAF_APC3","AAF APC3 -"],
+["GrpAAF_APC4","AAF APC4 -"],
 
 ["GrpAAF_TH1","AAF TH1 -"],
 ["GrpAAF_TH2","AAF TH2 -"],
@@ -275,6 +304,7 @@ _groups = [
 ["GrpAAF_TH7","AAF TH7 -"],
 ["GrpAAF_TH8","AAF TH8 -"],
 ["GrpAAF_AH1","AAF AH1 -"],
+["GrpAAF_FW1","AAF FW1 -"],
 
 
 // ====================================================================================
@@ -284,6 +314,7 @@ _groups = [
 
 ["GrpIFIA_CO","FIA I CO -"],
 ["GrpIFIA_DC","FIA I DC -"],
+["GrpIFIA_PLTHQ","FIA PLTHQ -"],
 
 ["GrpIFIA_ASL","FIA I ASL -"],
 ["GrpIFIA_A1","FIA I A1 -"],
@@ -320,6 +351,10 @@ _groups = [
 ["GrpIFIA_IFV7","FIA I IFV7 -"],
 ["GrpIFIA_IFV8","FIA I IFV8 -"],
 ["GrpIFIA_TNK1","FIA I TNK1 -"],
+["GrpIFIA_APC1","FIA I APC1 -"],
+["GrpIFIA_APC2","FIA I APC2 -"],
+["GrpIFIA_APC3","FIA I APC3 -"],
+["GrpIFIA_APC4","FIA I APC4 -"],
 
 ["GrpIFIA_TH1","FIA I TH1 -"],
 ["GrpIFIA_TH2","FIA I TH2 -"],
@@ -329,7 +364,8 @@ _groups = [
 ["GrpIFIA_TH6","FIA I TH6 -"],
 ["GrpIFIA_TH7","FIA I TH7 -"],
 ["GrpIFIA_TH8","FIA I TH8 -"],
-["GrpIFIA_AH1","FIA I AH1 -"]
+["GrpIFIA_AH1","FIA I AH1 -"],
+["GrpIFIA_FW1","FIA I FW1 -"]
 
 // Always make sure there's no comma after the last entry!
 


### PR DESCRIPTION
Implements issue #134

Issues of concern: 
* Pilots are given a 117F but they don't have a backpack or the space for it.
* The presets may not be correct for your radio layout but I'm not too familiar with it so it may need adjustments.
* I saw script errors related to acre_api_fnc_setPresetChannelField so that will need to be looked at.